### PR TITLE
Check for err opening the nitro security module.

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -83,14 +83,13 @@ func attest(nonce, userData, publicKey []byte) ([]byte, error) {
 		}
 	}()
 
-	// We ignore the error because of a bug that will return an error despite
-	// having obtained an attestation document:
-	// https://github.com/hf/nsm/issues/2
-	res, _ := s.Send(&request.Attestation{
+	if res, err := s.Send(&request.Attestation{
 		Nonce:     nonce,
 		UserData:  userData,
 		PublicKey: []byte{},
-	})
+	}); err != nil {
+		return err
+	}
 	if res.Error != "" {
 		return nil, errors.New(string(res.Error))
 	}

--- a/system.go
+++ b/system.go
@@ -40,10 +40,9 @@ func seedEntropyPool() error {
 
 	var written int
 	for totalWritten := 0; totalWritten < seedSize; {
-		// We ignore the error because of a bug that will return an error
-		// despite having obtained an attestation document:
-		// https://github.com/hf/nsm/issues/2
-		res, _ := s.Send(&request.GetRandom{})
+		if res, err := s.Send(&request.GetRandom{}); err != nil {
+			return err
+		}
 		if res.Error != "" {
 			return errors.New(string(res.Error))
 		}


### PR DESCRIPTION
This parsing issue causing the spurious error is supposedly
addressed upstream by the October 6 snapshot we're using.

NB, I didn't actually test this; just exploring the code.